### PR TITLE
Add ros entrypoint

### DIFF
--- a/cuda-ros.Dockerfile
+++ b/cuda-ros.Dockerfile
@@ -28,3 +28,10 @@ RUN rosdep init && \
 RUN apt-get update && apt-get install -y \
     ros-melodic-ros-core=1.4.1-0* \
     && rm -rf /var/lib/apt/lists/*
+
+# set entrypoint
+COPY ros_entrypoint.sh /ros_entrypoint.sh
+RUN chmod a+rx /ros_entrypoint.sh
+
+ENTRYPOINT [ "/ros_entrypoint.sh" ]
+CMD ["bash"]

--- a/ros_entrypoint.sh
+++ b/ros_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+
+# Run command
+exec "$@"


### PR DESCRIPTION
The base cuda-ros was missing an entrypoint that sources the ros `setup.bash` file.